### PR TITLE
Support PHP 7.3.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,7 @@
     "description": "Slider module for Magento 2",
     "type": "magento2-module",
     "require": {
-        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0",
+        "php": "~5.5.0|~5.6.0|~7.0.0|~7.1.0|~7.2.0|~7.3.0",
         "scandiweb/module-core": "~0.1.2",
         "claviska/simpleimage": "^3.3",
         "scandiweb/locale-resolver-fix": "^1.0"


### PR DESCRIPTION
Hello, 

I know that PHP 7.3 might not be officially supported by the extension but if it's not allowed in composer.json, the extension cannot be even tested against 7.3 branch.

Lukas