### PR TITLE
Fixed Slide Upload

### DIFF
--- a/Model/Slide.php
+++ b/Model/Slide.php
@@ -241,10 +241,12 @@ class Slide extends AbstractModel implements IdentityInterface
             $newFileName = $fileNameParts['dirname'] . '/' .
                 $fileNameParts['filename'] . '-' . $size . 'w.' . $fileNameParts['extension'];
 
+            $imageInfo = getimagesize($originalImagePath);
+
             $image
                 ->fromFile($originalImagePath)
                 ->resize($size)
-                ->toFile($newFileName, \mime_content_type($originalImagePath));
+                ->toFile($newFileName, $imageInfo['mime']);
         }
     }
 }


### PR DESCRIPTION
Fixes scandipwa/scandipwa#2244
Removed deprecated `mime_content_type()` since it broke slider upload.